### PR TITLE
QSP-10: Off-by-one error in withdrawAttribution fixed

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -128,7 +128,7 @@ contract Vault {
         returns (uint256 _retVal)
     {
         require(
-            attributions[msg.sender] > _attribution,
+            attributions[msg.sender] >= _attribution,
             "ERROR_WITHDRAW-ATTRIBUTION_BADCONDITOONS"
         );
         _retVal = _attribution.mul(valueAll()).div(totalAttributions);


### PR DESCRIPTION
Followed the guidance.

turned > to >=.