### PR TITLE
Shiba refactoring

### DIFF
--- a/contracts/CDSTemplate.sol
+++ b/contracts/CDSTemplate.sol
@@ -6,6 +6,7 @@ pragma solidity 0.8.7;
  * SPDX-License-Identifier: GPL-3.0
  */
 
+import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
@@ -17,11 +18,17 @@ import "./interfaces/ICDS.sol";
 import "./interfaces/IMinter.sol";
 
 contract CDSTemplate is InsureDAOERC20, ICDS {
-
     /**
      * EVENTS
      */
     event Deposit(address indexed depositor, uint256 amount, uint256 mint);
+    event Fund(address indexed depositor, uint256 amount, uint256 attribution);
+    event Defund(
+        address indexed depositor,
+        uint256 amount,
+        uint256 attribution
+    );
+
     event WithdrawRequested(
         address indexed withdrawer,
         uint256 amount,
@@ -31,7 +38,6 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
     event Compensated(address indexed index, uint256 amount);
     event Paused(bool paused);
     event MetadataChanged(string metadata);
-
 
     /**
      * Storage
@@ -45,6 +51,8 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
     IParameters public parameters;
     IRegistry public registry;
     IVault public vault;
+    uint256 public surplusPool;
+    uint256 public crowdPool;
 
     ///@notice user status management
     struct Withdrawal {
@@ -52,7 +60,6 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
         uint256 amount;
     }
     mapping(address => Withdrawal) public withdrawalReq;
-
 
     /**
      * @notice Throws if called by any account other than the owner.
@@ -99,11 +106,11 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
 
         initialized = true;
 
-        string memory name = "InsureDAO-CDS";
-        string memory symbol = "iCDS";
-        uint8 decimals = IERC20Metadata(_references[0]).decimals();
+        string memory _name = "InsureDAO-CDS";
+        string memory _symbol = "iCDS";
+        uint8 _decimals = IERC20Metadata(_references[0]).decimals();
 
-        initializeToken(name, symbol, decimals);
+        initializeToken(_name, _symbol, _decimals);
 
         parameters = IParameters(_references[2]);
         vault = IVault(parameters.getVault(_references[0]));
@@ -120,31 +127,67 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
      * @notice A liquidity provider supplies collatral to the pool and receives iTokens
      * @param _amount amount of token to deposit
      */
-    function deposit(uint256 _amount) public returns (uint256 _mintAmount) {
+    function deposit(uint256 _amount) external returns (uint256 _mintAmount) {
         require(paused == false, "ERROR: DEPOSIT_DISABLED");
         require(_amount > 0, "ERROR: DEPOSIT_ZERO");
 
-        uint256 _fee = parameters.getDepositFee(_amount, msg.sender);
-        uint256 _add = _amount - _fee;
-        uint256 _supply = totalSupply();
-        uint256 _totalLiquidity = totalLiquidity();
         //deposit and pay fees
-        vault.addValue(_add, msg.sender, address(this));
-        vault.addValue(_fee, msg.sender, parameters.getOwner());
+        uint256 _liquidity = vault.attributionValue(crowdPool);
+        uint256 _supply = totalSupply();
+        address[] memory _beneficiaries = new address[](1);
+        _beneficiaries[0] = address(this);
+        uint256[] memory _shares = new uint256[](1);
+        _shares[0] = 1e5;
+        crowdPool += vault.addValue(
+            _amount,
+            msg.sender,
+            [address(this), address(0)],
+            [uint256(1e5), uint256(0)],
+            1
+        );
 
-        //Calculate iToken value
-        if (_supply > 0 && _totalLiquidity > 0) {
-            _mintAmount = _add * _supply / _totalLiquidity;
-        } else if (_supply > 0 && _totalLiquidity == 0) {
-            _mintAmount = _add / _supply;
+        if (_supply > 0 && _liquidity > 0) {
+            _mintAmount = (_amount * _supply) / _liquidity;
+        } else if (_supply > 0 && _liquidity == 0) {
+            _mintAmount = _amount / _supply;
         } else {
-            _mintAmount = _add;
+            _mintAmount = _amount;
         }
 
         emit Deposit(msg.sender, _amount, _mintAmount);
 
         //mint iToken
         _mint(msg.sender, _mintAmount);
+    }
+
+    /**
+     * @notice A liquidity provider supplies collatral to the pool and receives iTokens
+     * @param _amount amount of token to deposit
+     */
+    function fund(uint256 _amount) external {
+        require(paused == false, "ERROR: DEPOSIT_DISABLED");
+
+        //deposit and pay fees
+        uint256 _attribution = vault.addValue(
+            _amount,
+            msg.sender,
+            [address(this), address(0)],
+            [uint256(1e5), uint256(0)],
+            1
+        );
+
+        surplusPool += _attribution;
+
+        emit Fund(msg.sender, _amount, _attribution);
+    }
+
+    function defund(uint256 _amount) external onlyOwner {
+        require(paused == false, "ERROR: DEPOSIT_DISABLED");
+
+        uint256 _attribution = vault.withdrawValue(_amount, msg.sender);
+        surplusPool -= _attribution;
+
+        emit Defund(msg.sender, _amount, _attribution);
     }
 
     /**
@@ -167,17 +210,19 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
      */
     function withdraw(uint256 _amount) external returns (uint256 _retVal) {
         //Calculate underlying value
-        _retVal = vault.underlyingValue(address(this)) * _amount / totalSupply();
+        _retVal = (vault.attributionValue(crowdPool) * _amount) / totalSupply();
         require(paused == false, "ERROR: WITHDRAWAL_PENDING");
         require(
-            withdrawalReq[msg.sender].timestamp + parameters.getLockup(msg.sender) < block.timestamp,
+            withdrawalReq[msg.sender].timestamp +
+                parameters.getLockup(msg.sender) <
+                block.timestamp,
             "ERROR: WITHDRAWAL_QUEUE"
         );
         require(
-            withdrawalReq[msg.sender].timestamp 
-            + parameters.getLockup(msg.sender) 
-            + parameters.getWithdrawable(msg.sender) 
-            > block.timestamp,
+            withdrawalReq[msg.sender].timestamp +
+                parameters.getLockup(msg.sender) +
+                parameters.getWithdrawable(msg.sender) >
+                block.timestamp,
             "ERROR: WITHDRAWAL_NO_ACTIVE_REQUEST"
         );
         require(
@@ -192,7 +237,7 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
         _burn(msg.sender, _amount);
 
         //Withdraw liquidity
-        vault.withdrawValue(_retVal, msg.sender);
+        crowdPool -= vault.withdrawValue(_retVal, msg.sender);
         emit Withdraw(msg.sender, _amount, _retVal);
     }
 
@@ -204,26 +249,32 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
      * @notice Compensate the shortage if an index is insolvent
      * @param _amount amount of underlier token to compensate shortage within index
      */
-    function compensate(uint256 _amount) external override {
+    function compensate(uint256 _amount)
+        external
+        override
+        returns (uint256 _compensated)
+    {
         require(registry.isListed(msg.sender));
         uint256 _available = vault.underlyingValue(address(this));
+        uint256 _crowdAttribution = crowdPool;
+        uint256 _surplusAttribution = surplusPool;
+        uint256 _attribution;
         if (_available >= _amount) {
-            //Normal case
-            vault.transferValue(_amount, msg.sender);
+            _compensated = _amount;
+            _attribution = vault.transferValue(_amount, msg.sender);
+            emit Compensated(msg.sender, _amount);
         } else {
-            uint256 _shortage = _amount - _available;
-            //transfer as much as possible
-            vault.transferValue(_available, msg.sender);
-            //check token address
-            address _token = vault.token();
-            //mint and swap for the shortage
-            IMinter(parameters.getMinter()).emergency_mint(_token, _shortage);
-            IERC20(_token).approve(address(vault), _shortage);
-            vault.addValue(_shortage, address(this), msg.sender);
+            _compensated = _available;
+            _attribution = vault.transferValue(_available, msg.sender);
+            emit Compensated(msg.sender, _available);
         }
-        emit Compensated(msg.sender, _amount);
+        crowdPool -=
+            (_crowdAttribution * _attribution) /
+            (_crowdAttribution + _surplusAttribution);
+        surplusPool -=
+            (_surplusAttribution * _attribution) /
+            (_crowdAttribution + _surplusAttribution);
     }
-
 
     /**
      * Utilities
@@ -243,7 +294,7 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
      */
     function rate() external view returns (uint256) {
         if (totalSupply() > 0) {
-            return totalLiquidity() * 1e18 / totalSupply();
+            return (vault.attributionValue(crowdPool) * 1e18) / totalSupply();
         } else {
             return 0;
         }
@@ -260,7 +311,8 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
             return 0;
         } else {
             return
-                _balance * (vault.underlyingValue(address(this)) / totalSupply());
+                _balance *
+                (vault.underlyingValue(address(this)) / totalSupply());
         }
     }
 
@@ -305,12 +357,11 @@ contract CDSTemplate is InsureDAOERC20, ICDS {
     ) internal virtual override {
         super._beforeTokenTransfer(from, to, amount);
 
-        if(from != address(0)){
+        if (from != address(0)) {
             uint256 _after = balanceOf(from) - amount;
             if (_after < withdrawalReq[from].amount) {
                 withdrawalReq[from].amount = _after;
             }
-
         }
     }
 }

--- a/contracts/IndexTemplate.sol
+++ b/contracts/IndexTemplate.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.7;
  * @title InsureDAO market template contract
  * SPDX-License-Identifier: GPL-3.0
  */
+import "hardhat/console.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
@@ -83,6 +84,13 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
     }
     mapping(address => Withdrawal) public withdrawalReq;
 
+    struct PoolStatus {
+        uint256 current;
+        uint256 available;
+        uint256 allocation;
+        address addr;
+    }
+
     ///@notice magic numbers
     uint256 public constant LEVERAGE_DIVISOR_1E3 = 1e3;
     uint256 public constant UTILIZATION_RATE_LENGTH_1E8 = 1e8;
@@ -132,11 +140,11 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
 
         initialized = true;
 
-        string memory name = "InsureDAO-Index";
-        string memory symbol = "iIndex";
-        uint8 decimals = IERC20Metadata(_references[0]).decimals();
+        string memory _name = "InsureDAO-Index";
+        string memory _symbol = "iIndex";
+        uint8 _decimals = IERC20Metadata(_references[0]).decimals();
 
-        initializeToken(name, symbol, decimals);
+        initializeToken(_name, _symbol, _decimals);
 
         parameters = IParameters(_references[2]);
         vault = IVault(parameters.getVault(_references[0]));
@@ -158,30 +166,33 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
         require(locked == false && paused == false, "ERROR: DEPOSIT_DISABLED");
         require(_amount > 0, "ERROR: DEPOSIT_ZERO");
 
-        uint256 _cds = parameters.getCDSPremium(_amount, msg.sender);
-        uint256 _fee = parameters.getDepositFee(_amount, msg.sender);
-        uint256 _add = _amount - _cds - _fee;
         uint256 _supply = totalSupply();
         uint256 _totalLiquidity = totalLiquidity();
-        vault.addValue(_add, msg.sender, address(this));
         vault.addValue(
-            _cds,
+            _amount,
             msg.sender,
-            address(registry.getCDS(address(this)))
+            [address(this), address(0)],
+            [uint256(1e5), uint256(0)],
+            1
         );
-        vault.addValue(_fee, msg.sender, parameters.getOwner());
 
         if (_supply > 0 && _totalLiquidity > 0) {
-            _mintAmount = (_add * _supply) / _totalLiquidity;
+            _mintAmount = (_amount * _supply) / _totalLiquidity;
         } else if (_supply > 0 && _totalLiquidity == 0) {
-            _mintAmount = _add / _supply;
+            _mintAmount = _amount / _supply;
         } else {
-            _mintAmount = _add;
+            _mintAmount = _amount;
         }
         emit Deposit(msg.sender, _amount, _mintAmount);
         //mint iToken
         _mint(msg.sender, _mintAmount);
-        adjustAlloc();
+        uint256 _liquidityAfter = _totalLiquidity + _amount;
+        uint256 _leverage = (totalAllocatedCredit * LEVERAGE_DIVISOR_1E3) /
+            _liquidityAfter;
+        //execut adjustAlloc only when the leverage became below target - lower-slack
+        if (targetLev - parameters.getLowerSlack(address(this)) > _leverage) {
+            _adjustAlloc(_liquidityAfter);
+        }
     }
 
     /**
@@ -204,19 +215,18 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
      */
     function withdraw(uint256 _amount) external returns (uint256 _retVal) {
         //Calculate underlying value
-        _retVal = (totalLiquidity() * _amount) / totalSupply();
 
+        uint256 _liquidty = totalLiquidity();
+        uint256 _lockup = parameters.getLockup(msg.sender);
+        uint256 _requestTime = withdrawalReq[msg.sender].timestamp;
+        _retVal = (_liquidty * _amount) / totalSupply();
         require(locked == false, "ERROR: WITHDRAWAL_PENDING");
         require(
-            withdrawalReq[msg.sender].timestamp +
-                parameters.getLockup(msg.sender) <
-                block.timestamp,
+            _requestTime + _lockup < block.timestamp,
             "ERROR: WITHDRAWAL_QUEUE"
         );
         require(
-            withdrawalReq[msg.sender].timestamp +
-                parameters.getLockup(msg.sender) +
-                parameters.getWithdrawable(msg.sender) >
+            _requestTime + _lockup + parameters.getWithdrawable(msg.sender) >
                 block.timestamp,
             "ERROR: WITHDRAWAL_NO_ACTIVE_REQUEST"
         );
@@ -231,15 +241,18 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
         );
 
         //reduce requested amount
-        withdrawalReq[msg.sender].amount =
-            withdrawalReq[msg.sender].amount -
-            _amount;
+        withdrawalReq[msg.sender].amount -= _amount;
         //Burn iToken
         _burn(msg.sender, _amount);
 
         //Check current leverage rate and get updated target total credit allocation
-        uint256 _liquidityAfter = totalLiquidity() - _retVal;
-        _adjustAlloc(_liquidityAfter);
+        uint256 _liquidityAfter = _liquidty - _retVal;
+        uint256 _leverage = (totalAllocatedCredit * LEVERAGE_DIVISOR_1E3) /
+            _liquidityAfter;
+        //execut adjustAlloc only when the leverage became above target + upper-slack
+        if (targetLev + parameters.getUpperSlack(address(this)) < _leverage) {
+            _adjustAlloc(_liquidityAfter);
+        }
         //Withdraw liquidity
         vault.withdrawValue(_retVal, msg.sender);
 
@@ -253,35 +266,33 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
      * @return _retVal withdrawable amount
      */
     function withdrawable() public view returns (uint256 _retVal) {
-        if (totalLiquidity() > 0) {
+        uint256 _leverage = leverage();
+
+        if (_leverage > targetLev) {
+            _retVal = 0;
+        } else {
+            uint256 _length = poolList.length;
+            uint256 _totalLiquidity = totalLiquidity();
             uint256 _lowest;
-            for (uint256 i = 0; i < poolList.length; i++) {
+            for (uint256 i = 0; i < _length; i++) {
                 if (allocPoints[poolList[i]] > 0) {
                     uint256 _utilization = IPoolTemplate(poolList[i])
                         .utilizationRate();
-                    if (i == 0) {
-                        _lowest = _utilization;
-                    }
-                    if (_utilization > _lowest) {
+                    if (i == 0 || _utilization > _lowest) {
                         _lowest = _utilization;
                     }
                 }
             }
-            if (leverage() > targetLev) {
-                _retVal = 0;
-            } else if (_lowest == 0) {
-                _retVal = totalLiquidity();
+            if (_lowest == 0) {
+                _retVal = _totalLiquidity;
             } else {
                 _retVal =
                     ((UTILIZATION_RATE_LENGTH_1E8 - _lowest) *
-                        totalLiquidity() *
+                        _totalLiquidity *
                         LEVERAGE_DIVISOR_1E3) /
                     UTILIZATION_RATE_LENGTH_1E8 /
-                    leverage() +
-                    _accruedPremiums();
+                    _leverage;
             }
-        } else {
-            _retVal = 0;
         }
     }
 
@@ -311,66 +322,69 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
     function _adjustAlloc(uint256 _liquidity) internal {
         //Check current leverage rate and get target total credit allocation
         uint256 _targetCredit = (targetLev * _liquidity) / LEVERAGE_DIVISOR_1E3;
-        address[] memory _poolList = new address[](poolList.length);
         uint256 _allocatable = _targetCredit;
         uint256 _allocatablePoints = totalAllocPoint;
+        uint256 _length = poolList.length;
+        PoolStatus[] memory _poolList = new PoolStatus[](_length);
+
         //Check each pool and if current credit allocation > target && it is impossble to adjust, then withdraw all availablle credit
-        for (uint256 i = 0; i < poolList.length; i++) {
-            if (poolList[i] != address(0)) {
+        for (uint256 i = 0; i < _length; i++) {
+            address _pool = poolList[i];
+            if (_pool != address(0)) {
+                uint256 _allocation = allocPoints[_pool];
                 //Target credit allocation for a pool
-                uint256 _target = (_targetCredit * allocPoints[poolList[i]]) /
-                    totalAllocPoint;
+                uint256 _target = (_targetCredit * _allocation) /
+                    _allocatablePoints;
                 //get how much has been allocated for a pool
-                uint256 _current = IPoolTemplate(poolList[i]).allocatedCredit(
+                uint256 _current = IPoolTemplate(_pool).allocatedCredit(
                     address(this)
                 );
                 //get how much liquidty is available to withdraw
-                uint256 _available = IPoolTemplate(poolList[i])
-                    .availableBalance();
+                uint256 _available = IPoolTemplate(_pool).availableBalance();
                 //if needed to withdraw credit but unable, then withdraw all available.
                 //Otherwise, skip.
                 if (
                     (_current > _target && _current - _target > _available) ||
-                    IPoolTemplate(poolList[i]).paused() == true
+                    IPoolTemplate(_pool).paused() == true
                 ) {
-                    IPoolTemplate(poolList[i]).withdrawCredit(_available);
-                    totalAllocatedCredit = totalAllocatedCredit - _available;
-                    _poolList[i] = address(0);
+                    IPoolTemplate(_pool).withdrawCredit(_available);
+                    totalAllocatedCredit -= _available;
+                    _poolList[i].addr = address(0);
                     _allocatable -= _current - _available;
-                    _allocatablePoints -= allocPoints[poolList[i]];
+                    _allocatablePoints -= _allocation;
                 } else {
-                    _poolList[i] = poolList[i];
+                    _poolList[i].addr = _pool;
+                    _poolList[i].current = _current;
+                    _poolList[i].available = _available;
+                    _poolList[i].allocation = _allocation;
                 }
             }
         }
         //Check pools that was not falling under the previous criteria, then adjust to meet the target credit allocation.
-        for (uint256 i = 0; i < _poolList.length; i++) {
-            if (_poolList[i] != address(0)) {
+        for (uint256 i = 0; i < _length; i++) {
+            if (_poolList[i].addr != address(0)) {
                 //Target credit allocation for a pool
-                uint256 _target = (_allocatable * allocPoints[poolList[i]]) /
+                uint256 _target = (_allocatable * _poolList[i].allocation) /
                     _allocatablePoints;
                 //get how much has been allocated for a pool
-                uint256 _current = IPoolTemplate(poolList[i]).allocatedCredit(
-                    address(this)
-                );
+                uint256 _current = _poolList[i].current;
                 //get how much liquidty is available to withdraw
-                uint256 _available = IPoolTemplate(poolList[i])
-                    .availableBalance();
+                uint256 _available = _poolList[i].available;
                 //Withdraw or Deposit credit
                 if (_current > _target && _available != 0) {
                     //if allocated credit is higher than the target, try to decrease
                     uint256 _decrease = _current - _target;
-                    IPoolTemplate(poolList[i]).withdrawCredit(_decrease);
-                    totalAllocatedCredit = totalAllocatedCredit - _decrease;
+                    IPoolTemplate(_poolList[i].addr).withdrawCredit(_decrease);
+                    totalAllocatedCredit -= _decrease;
                 }
                 if (_current < _target) {
                     //Sometimes we need to allocate more
                     uint256 _allocate = _target - _current;
-                    IPoolTemplate(poolList[i]).allocateCredit(_allocate);
-                    totalAllocatedCredit = totalAllocatedCredit + _allocate;
+                    IPoolTemplate(_poolList[i].addr).allocateCredit(_allocate);
+                    totalAllocatedCredit += _allocate;
                 }
                 if (_current == _target) {
-                    IPoolTemplate(poolList[i]).allocateCredit(0);
+                    IPoolTemplate(_poolList[i].addr).allocateCredit(0);
                 }
             }
         }
@@ -387,30 +401,47 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
      * 1) Compensate underlying pools from the liquidity of this pool
      * 2) If this pool is unable to cover a compensation, can get compensated from the CDS pool
      */
-    function compensate(uint256 _amount) external override {
+    function compensate(uint256 _amount)
+        external
+        override
+        returns (uint256 _compensated)
+    {
         require(
             allocPoints[msg.sender] > 0,
             "ERROR_COMPENSATE_UNAUTHORIZED_CALLER"
         );
-        if (vault.underlyingValue(address(this)) >= _amount) {
+        uint256 _value = vault.underlyingValue(address(this));
+        if (_value >= _amount) {
             //When the deposited value without earned premium is enough to cover
-            vault.repayDebt(_amount, msg.sender);
+            console.log("1");
+            vault.offsetDebt(_amount, msg.sender);
+            //vault.transferValue(_amount, msg.sender);
+            _compensated = _amount;
         } else {
             //When the deposited value without earned premium is *NOT* enough to cover
             //Withdraw credit to cashout the earnings
+            /*
             for (uint256 i = 0; i < poolList.length; i++) {
                 IPoolTemplate(poolList[i]).allocateCredit(0);
             }
+            */
+            console.log("2");
+            uint256 _shortage;
             if (totalLiquidity() < _amount) {
                 //Insolvency case
-                uint256 _shortage = _amount - totalLiquidity();
-                ICDS(registry.getCDS(address(this))).compensate(_shortage);
+                _shortage = _amount - _value;
+                uint256 _cds = ICDS(registry.getCDS(address(this))).compensate(
+                    _shortage
+                );
+                _compensated = _value + _cds;
             }
 
-            vault.transferValue(_amount, msg.sender);
+            //vault.transferValue(_amount, msg.sender);
+            vault.offsetDebt(_compensated, msg.sender);
+            //vault.transferValue(_amount, msg.sender);
         }
         adjustAlloc();
-        emit Compensated(msg.sender, _amount);
+        emit Compensated(msg.sender, _compensated);
     }
 
     /**

--- a/contracts/interfaces/ICDS.sol
+++ b/contracts/interfaces/ICDS.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.8.7;
 
 interface ICDS {
-    function compensate(uint256) external;
+    function compensate(uint256) external returns (uint256 _compensated);
 
     //function lock() external;
 

--- a/contracts/interfaces/IClearingHouse.sol
+++ b/contracts/interfaces/IClearingHouse.sol
@@ -1,0 +1,3 @@
+pragma solidity 0.8.7;
+
+interface IClearingHouse {}

--- a/contracts/interfaces/IIndexTemplate.sol
+++ b/contracts/interfaces/IIndexTemplate.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.8.7;
 
 interface IIndexTemplate {
-    function compensate(uint256) external;
+    function compensate(uint256) external returns (uint256 _compensated);
 
     function lock(uint256) external;
 

--- a/contracts/interfaces/IParameters.sol
+++ b/contracts/interfaces/IParameters.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.8.7;
 
 abstract contract IParameters {
-
     function setVault(address _token, address _vault) external virtual;
 
     function setLockup(address _address, uint256 _target) external virtual;
@@ -10,9 +9,9 @@ abstract contract IParameters {
 
     function setMindate(address _address, uint256 _target) external virtual;
 
-    function setCDSPremium(address _address, uint256 _target) external virtual;
+    function setLowerSlack(address _address, uint256 _target) external virtual;
 
-    function setDepositFee(address _address, uint256 _target) external virtual;
+    function setUpperSlack(address _address, uint256 _target) external virtual;
 
     function setWithdrawable(address _address, uint256 _target)
         external
@@ -24,7 +23,7 @@ abstract contract IParameters {
 
     function setMaxList(address _address, uint256 _target) external virtual;
 
-    function setFeeModel(address _address, address _target) external virtual;
+    function setFeeRate(address _address, uint256 _target) external virtual;
 
     function setCondition(bytes32 _reference, bytes32 _target) external virtual;
 
@@ -40,13 +39,7 @@ abstract contract IParameters {
         address _target
     ) external view virtual returns (uint256);
 
-    function getFee(uint256 _amount, address _target)
-        external
-        view
-        virtual
-        returns (uint256);
-
-    function getLockup(address _target) external view virtual returns (uint256);
+    function getFee(address _target) external view virtual returns (uint256);
 
     function getWithdrawable(address _target)
         external
@@ -66,17 +59,19 @@ abstract contract IParameters {
         virtual
         returns (uint256);
 
-    function getDepositFee(uint256 _amoun, address _targett)
+    function getUpperSlack(address _target)
         external
         view
         virtual
         returns (uint256);
 
-    function getCDSPremium(uint256 _amount, address _target)
+    function getLowerSlack(address _target)
         external
         view
         virtual
         returns (uint256);
+
+    function getLockup(address _target) external view virtual returns (uint256);
 
     function getCondition(bytes32 _reference)
         external

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -4,14 +4,18 @@ interface IVault {
     function addValue(
         uint256 _amount,
         address _from,
-        address _attribution
+        address[2] memory _beneficiaries,
+        uint256[2] memory _shares,
+        uint256 _length
     ) external returns (uint256 _attributions);
 
     function withdrawValue(uint256 _amount, address _to)
         external
         returns (uint256 _attributions);
 
-    function transferValue(uint256 _amount, address _destination) external;
+    function transferValue(uint256 _amount, address _destination)
+        external
+        returns (uint256 _attributions);
 
     function withdrawAttribution(uint256 _attribution, address _to)
         external
@@ -41,13 +45,19 @@ interface IVault {
         external
         returns (uint256 _attributions);
 
-    function repayDebt(uint256 _amount, address _target)
+    /*
+    function borrowAndTransfer(uint256 _amount, address _to)
+        external
+        returns (uint256 _attributions);
+    */
+
+    function offsetDebt(uint256 _amount, address _target)
         external
         returns (uint256 _attributions);
 
-    function settleDebt(address _debtor)
-        external
-        returns (uint256 _attributions);
+    function repayDebt(uint256 _amount, address _target) external;
 
     function debts(address _debtor) external view returns (uint256);
+
+    function transferDebt(uint256 _amount) external;
 }

--- a/contracts/mocks/SimplePoolMock.sol
+++ b/contracts/mocks/SimplePoolMock.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.8.7;
+
+contract SimplePoolMock {
+    constructor() {}
+
+    uint256 u;
+
+    function utilizationRate() external view returns (uint256) {
+        return u;
+    }
+
+    function changeU(uint256 _u) external {
+        u = _u;
+    }
+}


### PR DESCRIPTION
WIP: changed the followings

▼Redeem gas 
-Changed redeem not to call compensate in Index directly.
-Instead, redeem calls borrowValue and borrow payout amount from Vault
-When `resume` the market, it clear debt and liquidate funds within the pool and indexes

▼adjustAlloc
-Set "slack" for deposit/ withdraw in Index
-If the leverage rate change is within the upper or lower slack range, the function doesn't call adjustAlloc 

▼CDS 
-deleted deposit fee
-fund/defund function added(accrue surplus fee from the whole protocol)
-deposit/withdraw changed not to accrue premium

▼Index
-deleted deposit fee/CDS premium

▼Vault
-addValue  -> changed to enable mutiple USDC deposit at once.
-borrowValue/borrowAndTransfer/repayDebt/offsetDebt added

▼Parameter
FeeModel -> Changed to Fee that just returns fee rates

▼Overall
...some gas optimization
