### PR TITLE
fix issue-#330

### DIFF
--- a/contracts/PremiumModels/BondingPremium.sol
+++ b/contracts/PremiumModels/BondingPremium.sol
@@ -66,6 +66,11 @@ contract BondingPremium is IPremiumModel {
             _totalLiquidity >= _lockedAmount,
             "ERROR: _lockedAmount > _totalLiquidity"
         );
+
+        if (_totalLiquidity == 0) {
+            return 0;
+        }
+
         // utilization rate (0~1000000)
         uint256 _util = (_lockedAmount * BASE) / _totalLiquidity;
 


### PR DESCRIPTION
Fixed #330
https://github.com/code-423n4/2022-01-insure-findings/issues/330

I followed `getPremiumRate` which returns 0 when  _totalLiquidity = 0.