### PR TITLE
fixed #269

### DIFF
--- a/contracts/IndexTemplate.sol
+++ b/contracts/IndexTemplate.sol
@@ -460,8 +460,9 @@ contract IndexTemplate is InsureDAOERC20, IIndexTemplate, IUniversalMarket {
             if (totalLiquidity() < _amount) {
                 //Insolvency case
                 unchecked {
-                    _compensated = _value + ICDSTemplate(registry.getCDS(address(this))).compensate(_amount - _value);
+                    ICDSTemplate(registry.getCDS(address(this))).compensate(_amount - _value);
                 }
+                _compensated = vault.underlyingValue(address(this));
             }
             vault.offsetDebt(_compensated, msg.sender);
         }


### PR DESCRIPTION
Get the actual value the index has for the compensation after cds.compensate is called to avoid getting reverted due to precision loss.
https://github.com/code-423n4/2022-01-insure-findings/issues/269