### PR TITLE
`applyCover` and `applyBounty` should be allowed when paused

### DIFF
--- a/contracts/PoolTemplate.sol
+++ b/contracts/PoolTemplate.sol
@@ -696,7 +696,6 @@ contract PoolTemplate is InsureDAOERC20, IPoolTemplate, IUniversalMarket {
         string calldata _rawdata,
         string calldata _memo
     ) external override onlyOwner {
-        require(!paused, "ERROR: UNABLE_TO_APPLY");
         require(_incidentTimestamp < block.timestamp, "ERROR: INCIDENT_DATE");
 
         incident.payoutNumerator = _payoutNumerator;
@@ -732,7 +731,6 @@ contract PoolTemplate is InsureDAOERC20, IPoolTemplate, IUniversalMarket {
         address _contributor,
         uint256[] calldata _ids
     )external override onlyOwner {
-        require(!paused, "ERROR: MARKET_IS_PAUSED");
         require(marketStatus == MarketStatus.Trading, "ERROR: NOT_TRADING_STATUS");
 
         //borrow value just like redeem()


### PR DESCRIPTION
As when we have a potential hack event, we shall pause the pool first while investigating, so that no new insurance will be sold during the time we undertaking the investigation.

Therefore, when applyCover() and applyBounty(), most likely the pool will be in paused status.

And we should allow it rather than require the paused status to be lifted first.