### PR TITLE
Catch errors with ERC20 metadata

### DIFF
--- a/contracts/PoolTemplate.sol
+++ b/contracts/PoolTemplate.sol
@@ -191,16 +191,16 @@ contract PoolTemplate is InsureDAOERC20, IPoolTemplate, IUniversalMarket {
         );
         initialized = true;
 
-        string memory _name = string(
-            abi.encodePacked(
-                "InsureDAO-",
-                IERC20Metadata(_references[0]).name(),
-                "-Insurance"
-            )
-        );
-        string memory _symbol = string(
-            abi.encodePacked("i", IERC20Metadata(_references[0]).symbol())
-        );
+        string memory _name = "InsureDAO Insurance LP";
+        try IERC20Metadata(_references[0]).name() returns (string memory result) {
+            _name = string(abi.encodePacked("InsureDAO ", result, " Insurance LP"));
+        } catch {}
+
+        string memory _symbol = "iNsure";
+        try IERC20Metadata(_references[0]).symbol() returns (string memory result) {
+            _symbol = string(abi.encodePacked("i", result));
+        } catch {}
+
         uint8 _decimals = IERC20Metadata(_references[1]).decimals();
 
         initializeToken(_name, _symbol, _decimals);

--- a/test/unitary/PoolTemplate/unitPool.test.js
+++ b/test/unitary/PoolTemplate/unitPool.test.js
@@ -222,6 +222,12 @@ describe("Pool", function () {
   });
 
   describe("PoolTemplate", function () {
+    describe("metadata", function () {
+      it("should return correct metadata", async () => {
+        expect(await market.name()).to.equal("InsureDAO DAI Insurance LP");
+        expect(await market.symbol()).to.equal("iDAI");
+      })
+    });
     describe("insure", function () {
       beforeEach(async () => {
         await usdc.connect(alice).approve(vault.address, initialMint)


### PR DESCRIPTION
Some of ERC20, for example MakerDAO's MKR token, is not using string for token name and symbol.