### PR TITLE
Audit/v2/WP-L2 and L6

### DIFF
--- a/contracts/strategies/AaveV3Strategy.sol
+++ b/contracts/strategies/AaveV3Strategy.sol
@@ -289,15 +289,17 @@ contract AaveV3Strategy is IController {
         uint256 _claimable = getUnclaimedReward();
         if (_claimable == 0) revert NoRewardClaimable();
 
-        aaveReward.claimAllRewards(supplyingAssets, address(this));
-        emit RewardClaimed(address(aaveRewardToken), _claimable);
+        (address[] memory _rewards, uint256[] memory _gotRewards) = aaveReward.claimAllRewards(
+            supplyingAssets,
+            address(this)
+        );
 
-        uint256 _swapped = _swap(address(aaveRewardToken), address(usdc), aaveRewardToken.balanceOf(address(this)));
-
-        // compound swapped usdc
-        _utilize(_swapped);
-
-        managingFund += _swapped;
+        uint256 _rewardsCount = _rewards.length;
+        for (uint256 i = 0; i < _rewardsCount; i++) {
+            uint256 _swapped = _swap(_rewards[i], address(usdc), _gotRewards[i]);
+            // compound swapped usdc
+            _utilize(_swapped);
+        }
     }
 
     /**

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -103,7 +103,7 @@ module.exports = {
     },
   },
   paths: {
-    sources: "./contracts",
+    sources: ["./contracts", "./lib"],
     tests: "./test/unitary",
     cache: "./cache",
     artifacts: "./artifacts",

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -103,7 +103,7 @@ module.exports = {
     },
   },
   paths: {
-    sources: ["./contracts", "./lib"],
+    sources: "./contracts",
     tests: "./test/unitary",
     cache: "./cache",
     artifacts: "./artifacts",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
+    "@foundry-rs/hardhat-anvil": "^0.1.7",
+    "@foundry-rs/hardhat-forge": "^0.1.17",
     "@nomiclabs/hardhat-ethers": "^2.0.0",
     "@nomiclabs/hardhat-etherscan": "^3.1.0",
     "@nomiclabs/hardhat-waffle": "^2.0.1",

--- a/test/foundry/AaveV3Strategy/AaveV3StrategyError.t.sol
+++ b/test/foundry/AaveV3Strategy/AaveV3StrategyError.t.sol
@@ -45,8 +45,7 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
             IAaveV3Pool(aavePool),
             IAaveV3Reward(aaveReward),
             IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
+            IERC20(ausdc)
         );
         vm.expectRevert(ZeroAddress.selector);
         _newController.immigrate(address(0));
@@ -60,8 +59,7 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
             IAaveV3Pool(aavePool),
             IAaveV3Reward(aaveReward),
             IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
+            IERC20(ausdc)
         );
         vm.expectRevert();
         _newController.immigrate(alice);
@@ -75,8 +73,7 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
             IAaveV3Pool(aavePool),
             IAaveV3Reward(aaveReward),
             IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
+            IERC20(ausdc)
         );
         _newController.immigrate(address(strategy));
     }
@@ -89,8 +86,7 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
             IAaveV3Pool(aavePool),
             IAaveV3Reward(aaveReward),
             IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
+            IERC20(ausdc)
         );
         vm.expectRevert(AlreadyInUse.selector);
         strategy.immigrate(address(_newController));
@@ -140,42 +136,8 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
         strategy.setExchangeLogic(IExchangeLogic(alice));
     }
 
-    function testCannotSetAaveRewardTokenWithoutOwner() public {
-        vm.expectRevert(OnlyOwner.selector);
-        strategy.setAaveRewardToken(IERC20(aaveRewardToken));
-    }
-
-    function testCannotSetZeroAddressToAaveRewardToken() public {
-        vm.prank(deployer);
-        vm.expectRevert(ZeroAddress.selector);
-        strategy.setAaveRewardToken(IERC20(address(0)));
-    }
-
-    function testCannotWithdrawRewardWithoutOwner() public {
-        vm.expectRevert(OnlyOwner.selector);
-        strategy.withdrawReward(1);
-    }
-
-    function testCannotWithdrawRewardForAmountZero() public {
-        vm.prank(deployer);
-        vm.expectRevert(AmountZero.selector);
-        strategy.withdrawReward(0);
-    }
-
-    function testCannotWithdrawRewardForInsufficientAmount() public {
-        vm.prank(deployer);
-        vm.expectRevert(InsufficientRewardToWithdraw.selector);
-        strategy.withdrawReward(1);
-    }
-
     function testCannotWithdrawAllRewardWithoutOwner() public {
         vm.expectRevert(OnlyOwner.selector);
-        strategy.withdrawAllReward();
-    }
-
-    function testCannotWithdrawAllRewardForNoBalance() public {
-        vm.prank(deployer);
-        vm.expectRevert(NoRewardClaimable.selector);
         strategy.withdrawAllReward();
     }
 }

--- a/test/foundry/AaveV3Strategy/AaveV3StrategySetUp.sol
+++ b/test/foundry/AaveV3Strategy/AaveV3StrategySetUp.sol
@@ -61,8 +61,7 @@ abstract contract AaveV3StrategySetUp is Test {
             IAaveV3Pool(aavePool),
             IAaveV3Reward(aaveReward),
             IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
+            IERC20(ausdc)
         );
 
         vault.setController(address(strategy));


### PR DESCRIPTION
I agreed the recommendation and:
- removed `aaveRewardToken` state variable, getting multiple reward data from AaveV3RewardController
- calling `withdrawAllReward` in `emigrate` function