### PR TITLE
Audit/v2/WP-M1

### DIFF
--- a/test/foundry/AaveV3Strategy/AaveV3Strategy.t.sol
+++ b/test/foundry/AaveV3Strategy/AaveV3Strategy.t.sol
@@ -16,16 +16,14 @@ contract AaveV3StrategyTest is AaveV3StrategySetUp {
         strategy.setMaxManagingRatio(0.2e6); //10% => 20%
         strategy.adjustFund(); //+900
 
-        assertEq(strategy.managingFund(), 1_800 * 1e6);
-        assertApproxEqRel(IERC20(ausdc).balanceOf(address(strategy)), 1_800 * 1e6, 0.001e18);
+        assertApproxEqRel(strategy.managingFund(), 1_800 * 1e6, 0.001e18);
     }
 
     function testReturnFund() public {
         vm.prank(address(vault));
         strategy.returnFund(100 * 1e6);
 
-        assertEq(strategy.managingFund(), 800 * 1e6);
-        assertApproxEqRel(IERC20(ausdc).balanceOf(address(strategy)), 800 * 1e6, 0.001e18); // within 0.1%
+        assertApproxEqRel(strategy.managingFund(), 800 * 1e6, 0.001e18); // within 0.1%
     }
 
     function testMigration() public {
@@ -45,11 +43,9 @@ contract AaveV3StrategyTest is AaveV3StrategySetUp {
 
         //check old controller
         assertEq(strategy.managingFund(), 0);
-        assertEq(IERC20(ausdc).balanceOf(address(strategy)), 0);
 
         //check new controller
         assertEq(newController.managingFund(), 900 * 1e6);
-        assertEq(IERC20(ausdc).balanceOf(address(newController)), 900 * 1e6);
     }
 
     function testEmergencyExit() public {
@@ -69,7 +65,7 @@ contract AaveV3StrategyTest is AaveV3StrategySetUp {
         assertEq(strategy.totalValueAll(), 9_000 * 1e6);
     }
 
-    function testValueAll() public {
+    function testManagingFund() public {
         //managingFund: 900
         assertEq(strategy.managingFund(), 900 * 1e6);
     }

--- a/test/foundry/AaveV3Strategy/AaveV3StrategyError.t.sol
+++ b/test/foundry/AaveV3Strategy/AaveV3StrategyError.t.sol
@@ -52,21 +52,6 @@ contract AaveV3StrategyErrorTest is AaveV3StrategySetUp {
         _newController.immigrate(address(0));
     }
 
-    function testCannotImmigrateFromNonController() public {
-        IController _newController = new AaveV3Strategy(
-            ownership,
-            vault,
-            exchangeLogic,
-            IAaveV3Pool(aavePool),
-            IAaveV3Reward(aaveReward),
-            IERC20(usdc),
-            IERC20(ausdc),
-            IERC20(aaveRewardToken)
-        );
-        vm.expectRevert();
-        _newController.immigrate(alice);
-    }
-
     function testFailImmigrateWithoutApprove() public {
         IController _newController = new AaveV3Strategy(
             ownership,


### PR DESCRIPTION
I followed the recommendation so made these changes
- defined `managingFund()` function returning aUSDC realtime balance
- removed `managingFund` state variable as it did not represent underlying value correctly and we have no need to track principal